### PR TITLE
Chore/refine architecture

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -42,5 +42,5 @@
   "side_panel": {
     "default_path": "src/SidePanel/index.html"
   },
-  "permissions": ["sidePanel", "contextMenus", "storage", "activeTab", "tabs", "scripting"]
+  "permissions": ["sidePanel", "contextMenus", "storage", "activeTab", "tabs"]
 }

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -42,5 +42,5 @@
   "side_panel": {
     "default_path": "src/SidePanel/index.html"
   },
-  "permissions": ["sidePanel", "contextMenus", "storage", "activeTab", "tabs"]
+  "permissions": ["sidePanel", "contextMenus", "storage", "activeTab", "tabs", "scripting"]
 }

--- a/src/SidePanel/debug-score-seed.ts
+++ b/src/SidePanel/debug-score-seed.ts
@@ -7,7 +7,7 @@ import { MessageMediator, Unsubscribe } from "#shared/MessageMediator";
 import { BlackListStorage } from "#shared/black-list-storage/BlackListStorage";
 import { getActiveTab } from "#shared/utils";
 import { ConsentStorage } from "#shared/consent/ConsentStorage";
-import { DisplayData } from "#shared/messages";
+import { DisplayData } from "#shared/messages/display";
 import { CHROME_GLOBAL_VARIABLE } from "./dependency-injection/dom-symbols";
 
 const tagName = "debug-score-seed" as const;

--- a/src/SidePanel/debug-score-seed.ts
+++ b/src/SidePanel/debug-score-seed.ts
@@ -12,7 +12,7 @@ import { CHROME_GLOBAL_VARIABLE } from "./dependency-injection/dom-symbols";
 
 const tagName = "debug-score-seed" as const;
 
-export type DisplayChangeEvent = CustomEvent<DisplayData | undefined>;
+export type DisplayChangeEvent = CustomEvent<DisplayData>;
 
 @customElement(tagName)
 export class DebugScoreSeed extends LitElement {
@@ -33,7 +33,7 @@ export class DebugScoreSeed extends LitElement {
   );
 
   private clearScores(): void {
-    this.dispatchChangeEventWith(undefined);
+    this.dispatchChangeEventWith({ type: 'loading' });
   }
 
   private randomizeScores(): void {

--- a/src/SidePanel/debug-score-seed.ts
+++ b/src/SidePanel/debug-score-seed.ts
@@ -151,8 +151,12 @@ export class DebugScoreSeed extends LitElement {
     `;
   }
 
-  private sendDebugMessage(): void {
-    this.messageMediator.send("debug", this.debugInput.value);
+  private async sendDebugMessage(): Promise<void> {
+    const response = await this.messageMediator.send(
+      "debug",
+      this.debugInput.value
+    );
+    console.log("response from debug-score-seed", response);
   }
 
   protected render(): TemplateResult {

--- a/src/SidePanel/debug-score-seed.ts
+++ b/src/SidePanel/debug-score-seed.ts
@@ -1,13 +1,14 @@
 import { LitElement, html, TemplateResult } from "lit";
-import { customElement, state } from "lit/decorators.js";
+import { customElement, query, state } from "lit/decorators.js";
 import { EmotionScores } from "#shared/emotion-scores";
 import { commonStyle, structuralStyles } from "./shared-styles/common.style";
 import { container } from "tsyringe";
-import { MessageMediator } from "#shared/MessageMediator";
+import { MessageMediator, Unsubscribe } from "#shared/MessageMediator";
 import { BlackListStorage } from "#shared/black-list-storage/BlackListStorage";
 import { getActiveTab } from "#shared/utils";
 import { ConsentStorage } from "#shared/consent/ConsentStorage";
 import { DisplayData } from "#shared/messages";
+import { CHROME_GLOBAL_VARIABLE } from "./dependency-injection/dom-symbols";
 
 const tagName = "debug-score-seed" as const;
 
@@ -23,6 +24,13 @@ export class DebugScoreSeed extends LitElement {
 
   @state()
   private isConsentAccepted?: boolean;
+
+  @query("input", true)
+  private debugInput!: HTMLInputElement;
+
+  private chromeInstance = container.resolve<typeof chrome>(
+    CHROME_GLOBAL_VARIABLE
+  );
 
   private clearScores(): void {
     this.dispatchChangeEventWith(undefined);
@@ -72,8 +80,8 @@ export class DebugScoreSeed extends LitElement {
   }
 
   private openConsentPage(): void {
-    chrome.tabs.create({
-      url: chrome.runtime.getURL("src/consent/consent.html"),
+    this.chromeInstance.tabs.create({
+      url: this.chromeInstance.runtime.getURL("src/consent/consent.html"),
     });
   }
 
@@ -141,8 +149,16 @@ export class DebugScoreSeed extends LitElement {
     `;
   }
 
-  public render(): TemplateResult {
+  private sendDebugMessage(): void {
+    this.messageMediator.send("debug", this.debugInput.value);
+  }
+
+  protected render(): TemplateResult {
     return html`
+      <div class="shadow-sm d-flex align-items-center">
+        <button @click=${this.sendDebugMessage}>Send debug message</button>
+        <input />
+      </div>
       <div class="shadow-sm d-flex align-items-center">
         ${this.renderScoreSeeders()} ${this.renderNonParsableSeeders()}
       </div>
@@ -153,6 +169,21 @@ export class DebugScoreSeed extends LitElement {
         ${this.renderConsentDebuggers()}
       </div>
     `;
+  }
+
+  private unsubscribeDebugMessage?: Unsubscribe;
+
+  public connectedCallback(): void {
+    super.connectedCallback();
+    this.unsubscribeDebugMessage = this.messageMediator.listen(
+      "debug",
+      console.log
+    );
+  }
+
+  public disconnectedCallback(): void {
+    this.unsubscribeDebugMessage?.();
+    super.disconnectedCallback();
   }
 }
 

--- a/src/SidePanel/debug-score-seed.ts
+++ b/src/SidePanel/debug-score-seed.ts
@@ -64,10 +64,12 @@ export class DebugScoreSeed extends LitElement {
   }
 
   private async loadScoresForCurrentSite(): Promise<void> {
-    // TODO: parse --> analyze --> display
-    // <-- parse <-- analyze (should return EmotionScores)
-    const activeTab = await getActiveTab();
-    this.messageMediator.send("parse", undefined, activeTab.id);
+    const activeTab = await getActiveTab(this.chromeInstance.tabs);
+    this.messageMediator.send(
+      "getEvaluation",
+      { tabId: activeTab.id!, windowId: activeTab.windowId },
+      activeTab.id
+    );
   }
 
   private async clearBlackList(): Promise<void> {

--- a/src/SidePanel/dependency-injection/dom-symbols.ts
+++ b/src/SidePanel/dependency-injection/dom-symbols.ts
@@ -1,3 +1,4 @@
 export const LOCAL_STORAGE_SYMBOL = Symbol("symbol for local storage");
 export const WINDOW_SYMBOL = Symbol("symbol for window");
 export const DOCUMENT_SYMBOL = Symbol("symbol for window");
+export const CHROME_GLOBAL_VARIABLE = Symbol("symbol for chrome variable");

--- a/src/SidePanel/dependency-injection/init-di.ts
+++ b/src/SidePanel/dependency-injection/init-di.ts
@@ -3,6 +3,7 @@ import { BlackListStorage } from "#shared/black-list-storage/BlackListStorage";
 import { MessageMediator } from "#shared/MessageMediator";
 import { SupervisorStorage } from "#shared/supervisor/SupervisorStorage";
 import {
+  CHROME_GLOBAL_VARIABLE,
   DOCUMENT_SYMBOL,
   LOCAL_STORAGE_SYMBOL,
   WINDOW_SYMBOL,
@@ -12,6 +13,7 @@ import { ConsentStorage } from "#shared/consent/ConsentStorage";
 container.register(LOCAL_STORAGE_SYMBOL, { useValue: localStorage });
 container.register(WINDOW_SYMBOL, { useValue: window });
 container.register(DOCUMENT_SYMBOL, { useValue: document });
+container.register(CHROME_GLOBAL_VARIABLE, { useValue: chrome });
 
 container.register(BlackListStorage, BlackListStorage, {
   lifecycle: Lifecycle.Singleton,

--- a/src/SidePanel/side-panel/score-display/stv-display-data.ts
+++ b/src/SidePanel/side-panel/score-display/stv-display-data.ts
@@ -3,7 +3,7 @@ import { localized } from "@lit/localize";
 import { customElement, property } from "lit/decorators.js";
 import { commonStyle } from "../../shared-styles/common.style";
 import { Theme } from "#shared/theme-colors";
-import { DisplayData } from "#shared/messages";
+import { DisplayData } from "#shared/messages/display";
 
 const tagName = "stv-display-data" as const;
 

--- a/src/SidePanel/side-panel/score-display/stv-display-data.ts
+++ b/src/SidePanel/side-panel/score-display/stv-display-data.ts
@@ -23,7 +23,7 @@ export class StvDisplayData extends LitElement {
   ];
 
   @property({ type: Object })
-  public displayData: DisplayData | undefined;
+  public displayData!: DisplayData;
 
   @property({ type: String })
   public theme!: Theme;
@@ -38,7 +38,7 @@ export class StvDisplayData extends LitElement {
   }
 
   private renderDisplayer(): TemplateResult {
-    if (this.displayData === undefined)
+    if (this.displayData.type === 'loading')
       return html`<stv-loading-indicator></stv-loading-indicator>`;
     if (this.displayData.type === "displayable")
       return html`

--- a/src/SidePanel/side-panel/score-display/stv-exception-display.ts
+++ b/src/SidePanel/side-panel/score-display/stv-exception-display.ts
@@ -2,7 +2,7 @@ import { css, html, LitElement, TemplateResult } from "lit";
 import { localized, msg } from "@lit/localize";
 import { customElement, property } from "lit/decorators.js";
 import { commonStyle } from "../../shared-styles/common.style";
-import { ExceptionDisplayData } from "#shared/messages";
+import { ExceptionDisplayData } from "#shared/messages/display";
 import unsupportedLanguageIcon from "#assets/images/evaluation-exceptions/unsupported-language.svg?no-inline";
 import computerFailIcon from "#assets/images/evaluation-exceptions/computer-fail.svg?no-inline";
 import contractDenyIcon from "#assets/images/evaluation-exceptions/contract-deny.svg?no-inline";

--- a/src/SidePanel/side-panel/stv-side-panel.ts
+++ b/src/SidePanel/side-panel/stv-side-panel.ts
@@ -6,6 +6,7 @@ import type { Theme } from "#shared/theme-colors";
 import type { DisplayChangeEvent } from "../debug-score-seed";
 import { container } from "tsyringe";
 import { MessageMediator, Unsubscribe } from "#shared/MessageMediator";
+import { CHROME_GLOBAL_VARIABLE } from "../dependency-injection/dom-symbols";
 
 const tagName = "stv-side-panel" as const;
 @customElement(tagName)
@@ -45,6 +46,9 @@ export class StvSidePanel extends LitElement {
   private messageListener = (displayData: DisplayData): void => {
     this.displayData = displayData;
   };
+  private chromeInstance: typeof chrome = container.resolve(
+    CHROME_GLOBAL_VARIABLE
+  );
 
   private handleDisplayFromDebug = (ev: DisplayChangeEvent): void => {
     this.displayData = ev.detail || undefined;
@@ -57,9 +61,8 @@ export class StvSidePanel extends LitElement {
       this.messageListener
     );
 
-    // TODO: extract chrome and inject it
     // why do we need this port? --- to see from worker if the sidepanel is opened and closed
-    this.port = chrome.runtime.connect({ name: "sidepanel" });
+    this.port = this.chromeInstance.runtime.connect({ name: "sidepanel" });
   }
 
   public disconnectedCallback(): void {

--- a/src/SidePanel/side-panel/stv-side-panel.ts
+++ b/src/SidePanel/side-panel/stv-side-panel.ts
@@ -38,7 +38,7 @@ export class StvSidePanel extends LitElement {
   public theme!: Theme;
 
   @state()
-  private displayData?: DisplayData;
+  private displayData: DisplayData = { type: "loading" };
 
   private messageMediator = container.resolve(MessageMediator);
   private chromeInstance: typeof chrome = container.resolve(
@@ -46,7 +46,7 @@ export class StvSidePanel extends LitElement {
   );
   private sendEvaluationUnsubscribe?: Unsubscribe;
 
-  private messageListener = async (
+  private handleEvaluationResponse = async (
     evaluationResponse: SendEvaluationEvent["message"]
   ): Promise<void> => {
     const activeTab = await getActiveTab(this.chromeInstance.tabs);
@@ -60,27 +60,28 @@ export class StvSidePanel extends LitElement {
   };
 
   private handleDisplayFromDebug = (ev: DisplayChangeEvent): void => {
-    this.displayData = ev.detail || undefined;
+    this.displayData = ev.detail;
   };
 
   private handleTabChange = async (
     activeInfo: chrome.tabs.TabActiveInfo
   ): Promise<void> => {
     const tab = await this.chromeInstance.tabs.get(activeInfo.tabId);
-    if (isUsualTab(tab))
+    if (isUsualTab(tab)) {
+      this.displayData = { type: "loading" };
       this.messageMediator.send(
         "getEvaluation",
         { tabId: tab.id, windowId: tab.windowId },
         tab.id
       );
-    else this.displayData = { type: "inner-page" };
+    } else this.displayData = { type: "inner-page" };
   };
 
   public async connectedCallback(): Promise<void> {
     super.connectedCallback();
     this.sendEvaluationUnsubscribe = this.messageMediator.listen(
       "sendEvaluation",
-      this.messageListener
+      this.handleEvaluationResponse
     );
     // Listen for tab switches (when a tab is activated)
     this.chromeInstance.tabs.onActivated.addListener(this.handleTabChange);

--- a/src/SidePanel/side-panel/stv-side-panel.ts
+++ b/src/SidePanel/side-panel/stv-side-panel.ts
@@ -1,11 +1,12 @@
 import { LitElement, html, css, TemplateResult } from "lit";
 import { customElement, state, property } from "lit/decorators.js";
-import type { DisplayData } from "#shared/messages";
+import type { DisplayData, SendEvaluationEvent } from "#shared/messages";
 import { commonStyle, structuralStyles } from "../shared-styles/common.style";
 import type { Theme } from "#shared/theme-colors";
 import type { DisplayChangeEvent } from "../debug-score-seed";
 import { container } from "tsyringe";
 import { MessageMediator, Unsubscribe } from "#shared/MessageMediator";
+import { getActiveTab, isUsualTab } from "#shared/utils";
 import { CHROME_GLOBAL_VARIABLE } from "../dependency-injection/dom-symbols";
 
 const tagName = "stv-side-panel" as const;
@@ -40,36 +41,61 @@ export class StvSidePanel extends LitElement {
   private displayData?: DisplayData;
 
   private messageMediator = container.resolve(MessageMediator);
-  private unsubscribe?: Unsubscribe;
-
-  private port: chrome.runtime.Port | undefined;
-  private messageListener = (displayData: DisplayData): void => {
-    this.displayData = displayData;
-  };
   private chromeInstance: typeof chrome = container.resolve(
     CHROME_GLOBAL_VARIABLE
   );
+  private sendEvaluationUnsubscribe?: Unsubscribe;
+
+  private messageListener = async (
+    evaluationResponse: SendEvaluationEvent["message"]
+  ): Promise<void> => {
+    const activeTab = await getActiveTab(this.chromeInstance.tabs);
+    if (
+      activeTab.id !== evaluationResponse.tabId ||
+      activeTab.windowId !== evaluationResponse.windowId
+    )
+      return;
+
+    this.displayData = evaluationResponse.displayData;
+  };
 
   private handleDisplayFromDebug = (ev: DisplayChangeEvent): void => {
     this.displayData = ev.detail || undefined;
   };
 
-  public connectedCallback(): void {
+  private handleTabChange = async (
+    activeInfo: chrome.tabs.TabActiveInfo
+  ): Promise<void> => {
+    const tab = await this.chromeInstance.tabs.get(activeInfo.tabId);
+    if (isUsualTab(tab))
+      this.messageMediator.send(
+        "getEvaluation",
+        { tabId: tab.id, windowId: tab.windowId },
+        tab.id
+      );
+    else this.displayData = { type: "inner-page" };
+  };
+
+  public async connectedCallback(): Promise<void> {
     super.connectedCallback();
-    this.unsubscribe = this.messageMediator.listen(
-      "display",
+    this.sendEvaluationUnsubscribe = this.messageMediator.listen(
+      "sendEvaluation",
       this.messageListener
     );
+    // Listen for tab switches (when a tab is activated)
+    this.chromeInstance.tabs.onActivated.addListener(this.handleTabChange);
 
-    // why do we need this port? --- to see from worker if the sidepanel is opened and closed
-    this.port = this.chromeInstance.runtime.connect({ name: "sidepanel" });
+    const activeTab = await getActiveTab(this.chromeInstance.tabs);
+    this.handleTabChange({
+      tabId: activeTab.id!,
+      windowId: activeTab.windowId,
+    });
   }
 
   public disconnectedCallback(): void {
+    this.sendEvaluationUnsubscribe?.();
+    this.chromeInstance.tabs.onActivated.removeListener(this.handleTabChange);
     super.disconnectedCallback();
-
-    this.unsubscribe?.();
-    this.port?.disconnect();
   }
 
   public render(): TemplateResult {

--- a/src/SidePanel/side-panel/stv-side-panel.ts
+++ b/src/SidePanel/side-panel/stv-side-panel.ts
@@ -1,6 +1,7 @@
 import { LitElement, html, css, TemplateResult } from "lit";
 import { customElement, state, property } from "lit/decorators.js";
-import type { DisplayData, SendEvaluationEvent } from "#shared/messages";
+import type { DisplayData } from "#shared/messages/display";
+import type { SendEvaluationEvent } from "#shared/messages/evaluation";
 import { commonStyle, structuralStyles } from "../shared-styles/common.style";
 import type { Theme } from "#shared/theme-colors";
 import type { DisplayChangeEvent } from "../debug-score-seed";

--- a/src/SidePanel/side-panel/stv-toolbar.ts
+++ b/src/SidePanel/side-panel/stv-toolbar.ts
@@ -2,6 +2,8 @@ import { css, html, LitElement, TemplateResult } from "lit";
 import { customElement } from "lit/decorators.js";
 import { commonStyle } from "../shared-styles/common.style";
 import { ThemeColors, themes } from "#shared/theme-colors";
+import { container } from "tsyringe";
+import { CHROME_GLOBAL_VARIABLE } from "../dependency-injection/dom-symbols";
 
 const tagName = "stv-toolbar" as const;
 
@@ -22,6 +24,10 @@ export class StvToolbar extends LitElement {
     `,
   ];
 
+  private chromeInstance: typeof chrome = container.resolve(
+    CHROME_GLOBAL_VARIABLE
+  );
+
   private get themeIcon(): string {
     const toolbarIconKey: keyof ThemeColors = "--toolbar-icon-name";
     const themeIconCssVariable = this.computedStyleMap().get(toolbarIconKey);
@@ -30,8 +36,7 @@ export class StvToolbar extends LitElement {
       themeIconCssVariable?.toString() || themes.dark[toolbarIconKey];
     const themeIconAbsolutePath = `images/theme-icons/${themeIconName}`;
 
-    // TODO: inject chrome.runtime
-    const filePath = chrome.runtime.getURL(themeIconAbsolutePath);
+    const filePath = this.chromeInstance.runtime.getURL(themeIconAbsolutePath);
     return filePath;
   }
 

--- a/src/SidePanel/side-panel/user-black-list/stv-user-black-list.ts
+++ b/src/SidePanel/side-panel/user-black-list/stv-user-black-list.ts
@@ -11,6 +11,7 @@ import { SearchEvent } from "../../shared/search-event";
 import { MessageMediator, Unsubscribe } from "#shared/MessageMediator";
 import { getActiveTab } from "#shared/utils";
 import { getDisposeDispatcher } from "#shared/ui-related/dispose-event";
+import { CHROME_GLOBAL_VARIABLE } from "../../dependency-injection/dom-symbols";
 
 const tagName = "stv-user-black-list" as const;
 
@@ -56,6 +57,10 @@ export class StvUserBlackList extends LitElement {
 
   private blackListService = container.resolve(BlackListStorage);
 
+  private chromeInstance = container.resolve<typeof chrome>(
+    CHROME_GLOBAL_VARIABLE
+  );
+
   @state()
   private userBlackList: Array<string> | undefined;
 
@@ -63,7 +68,7 @@ export class StvUserBlackList extends LitElement {
   private searchTerm: string = "";
   private async addCurrentDomain(): Promise<void> {
     this.userBlackList = undefined;
-    const activeTab = await getActiveTab();
+    const activeTab = await getActiveTab(this.chromeInstance.tabs);
     const primaryDomain = await this.messageMediator.send(
       "getPrimaryDomain",
       undefined,

--- a/src/SidePanel/stv-ask-for-consent.ts
+++ b/src/SidePanel/stv-ask-for-consent.ts
@@ -2,6 +2,8 @@ import { LitElement, html, css, TemplateResult } from "lit";
 import { customElement } from "lit/decorators.js";
 import { commonStyle } from "./shared-styles/common.style";
 import { localized, msg } from "@lit/localize";
+import { container } from "tsyringe";
+import { CHROME_GLOBAL_VARIABLE } from "./dependency-injection/dom-symbols";
 
 const tagName = "stv-ask-for-consent" as const;
 
@@ -31,11 +33,13 @@ export class StvAskForConsent extends LitElement {
     `,
   ];
 
+  private chromeInstance: typeof chrome = container.resolve(CHROME_GLOBAL_VARIABLE);
+
   private async displayConsentPage(): Promise<void> {
     // https://stackoverflow.com/questions/25225964/is-there-a-way-to-focus-on-a-specific-tab-in-chrome-via-plugin
 
-    const consentPageURL = chrome.runtime.getURL("src/consent/consent.html");
-    const [alreadyOpenedConsentTab] = await chrome.tabs.query({
+    const consentPageURL = this.chromeInstance.runtime.getURL("src/consent/consent.html");
+    const [alreadyOpenedConsentTab] = await this.chromeInstance.tabs.query({
       /*
         url string | string[] optional
         Match tabs against one or more URL patterns. Fragment identifiers are not matched.
@@ -44,8 +48,8 @@ export class StvAskForConsent extends LitElement {
       url: consentPageURL,
     });
     if (!alreadyOpenedConsentTab || !alreadyOpenedConsentTab.id)
-      chrome.tabs.create({ url: consentPageURL });
-    else chrome.tabs.update(alreadyOpenedConsentTab.id, { active: true });
+      this.chromeInstance.tabs.create({ url: consentPageURL });
+    else this.chromeInstance.tabs.update(alreadyOpenedConsentTab.id, { active: true });
   }
 
   protected render(): TemplateResult {

--- a/src/content/Consultant/DefaultConsultant.ts
+++ b/src/content/Consultant/DefaultConsultant.ts
@@ -41,7 +41,7 @@ export class DefaultConsultant implements Consultant {
     }
 
     const normalizedScore = totalScore / totalEmotionValue;
-    // TODO: check this min-max
+
     const harmfulnessScore = Math.min(Math.max(normalizedScore, 0), 1);
     return harmfulnessScore;
   }

--- a/src/content/content.ts
+++ b/src/content/content.ts
@@ -36,12 +36,8 @@ const isConsentDeclined = async (): Promise<boolean> => {
 let cachedEvaluation: DisplayableData | undefined = undefined;
 // TODO: make getEvaluation cached until it resolves as non-displayable
 const getEvaluation = async (): Promise<DisplayData> => {
-  // TODO: handle this
-  if (await isConsentDeclined()) {
-    console.log("should not parse things");
-    // return
-  }
-
+  if (await isConsentDeclined())
+    return { type: "error", errorMessage: "Consent is not accepted." };
   if (await isSupervisionOff()) return { type: "off-supervision-mode" };
   if (await isCurrentPageBlackListed()) return { type: "black-listed" };
 

--- a/src/content/content.ts
+++ b/src/content/content.ts
@@ -9,63 +9,98 @@ import { ConsultantProvider } from "./Consultant/ConsultantProvider";
 import { SupervisorProvider } from "./Supervisor/SupervisorProvider";
 import { SupervisionMode } from "#shared/supervisor/supervision-mode";
 import { ConsentStorage } from "#shared/consent/ConsentStorage";
+import { DisplayableData, DisplayData } from "#shared/messages";
 
-const blackListStorage = new BlackListStorage();
-const supervisorStorage = new SupervisorStorage();
-const messageMediator = new MessageMediator();
-const consentStorage = new ConsentStorage();
-const sentivisor = new Sentivisor(
-  new ConsultantProvider(),
-  new SupervisorProvider(supervisorStorage, blackListStorage)
-);
-
-const isCurrentPageBlackListed = (): Promise<boolean> => {
-  const primaryDomain = getPrimaryDomain();
-  return blackListStorage.isDomainBlacklisted(primaryDomain);
-};
-
-const isSupervisionOff = async (): Promise<boolean> => {
-  return (await supervisorStorage.getVisionMode()) === SupervisionMode.off;
-};
-
-const isConsentDeclined = async (): Promise<boolean> => {
-  return !(await consentStorage.getConsent());
-};
-
-const parseContent = async () => {
-  if (await isConsentDeclined()) return;
-
-  if (await isSupervisionOff()) {
-    messageMediator.send("display", { type: "off-supervision-mode" });
-    return;
+declare global {
+  interface Window {
+    __SENTIVISOR_CONTENT_GUARD_FLAG__: boolean;
   }
-  if (await isCurrentPageBlackListed()) {
-    messageMediator.send("display", { type: "black-listed" });
+}
+
+function run() {
+  if (window.__SENTIVISOR_CONTENT_GUARD_FLAG__) {
+    console.log("BINGOOOO");
     return;
   }
 
-  const allTexts: string = document.body.innerText;
-  const lang: string = checkLanguage(allTexts);
+  window.__SENTIVISOR_CONTENT_GUARD_FLAG__ = true;
 
-  if (!isAllowedLanguage(lang)) {
-    messageMediator.send("display", { type: "unsupported-language" });
-    return;
-  }
+  const blackListStorage = new BlackListStorage();
+  const supervisorStorage = new SupervisorStorage();
+  const messageMediator = new MessageMediator();
+  const consentStorage = new ConsentStorage();
+  const sentivisor = new Sentivisor(
+    new ConsultantProvider(),
+    new SupervisorProvider(supervisorStorage, blackListStorage)
+  );
 
-  const url = `${location.origin}${location.pathname}`;
-  messageMediator.send("analyze", { language: lang, text: allTexts, url });
-};
+  const isCurrentPageBlackListed = (): Promise<boolean> => {
+    const primaryDomain = getPrimaryDomain();
+    return blackListStorage.isDomainBlacklisted(primaryDomain);
+  };
 
-messageMediator.listen("display", (emotionAnalysis) => {
-  if (emotionAnalysis.type !== "displayable") return;
+  const isSupervisionOff = async (): Promise<boolean> => {
+    return (await supervisorStorage.getVisionMode()) === SupervisionMode.off;
+  };
 
-  sentivisor.handleEmotionAnalysis(emotionAnalysis.emotionScores);
-});
+  const isConsentDeclined = async (): Promise<boolean> => {
+    return !(await consentStorage.getConsent());
+  };
 
-messageMediator.listen("parse", parseContent);
+  let cachedEvaluation: DisplayableData | undefined = undefined;
 
-messageMediator.listen("getPrimaryDomain", (_msg, _sender, sendResponse) => {
-  sendResponse(getPrimaryDomain());
-});
+  const getEvaluation = async (): Promise<DisplayData> => {
+    // TODO: handle this
+    if (await isConsentDeclined()) {
+      console.log("should not parse things");
+      // return
+    }
 
-parseContent();
+    if (await isSupervisionOff()) return { type: "off-supervision-mode" };
+    if (await isCurrentPageBlackListed()) return { type: "black-listed" };
+
+    const allTexts: string = document.body.innerText;
+    const lang: string = checkLanguage(allTexts);
+
+    if (!isAllowedLanguage(lang)) return { type: "unsupported-language" };
+
+    const url = `${location.origin}${location.pathname}`;
+
+    const emotionAnalysis =
+      cachedEvaluation ||
+      (await messageMediator.send("analyze", {
+        language: lang,
+        text: allTexts,
+        url,
+      }));
+
+    if (emotionAnalysis.type === "displayable")
+      cachedEvaluation = emotionAnalysis;
+
+    return emotionAnalysis!;
+  };
+
+  messageMediator.listen("getPrimaryDomain", (_msg, _sender, sendResponse) => {
+    sendResponse(getPrimaryDomain());
+  });
+
+  messageMediator.listen("getEvaluation", async (tabInfo) => {
+    messageMediator.send("sendEvaluation", {
+      displayData: await getEvaluation(),
+      ...tabInfo,
+    });
+  });
+
+  const runOnce = async (): Promise<void> => {
+    const alreadyCalledSentivisor = Boolean(cachedEvaluation);
+    if (alreadyCalledSentivisor) return;
+    const emotionAnalysis = await getEvaluation();
+    // TODO: push to sidepanel
+
+    if (emotionAnalysis.type !== "displayable") return;
+    sentivisor.handleEmotionAnalysis(emotionAnalysis.emotionScores);
+  };
+  runOnce();
+}
+
+run();

--- a/src/content/content.ts
+++ b/src/content/content.ts
@@ -11,79 +11,88 @@ import { SupervisionMode } from "#shared/supervisor/supervision-mode";
 import { ConsentStorage } from "#shared/consent/ConsentStorage";
 import { DisplayableData, DisplayData, TabInfo } from "#shared/messages";
 
-  const blackListStorage = new BlackListStorage();
-  const supervisorStorage = new SupervisorStorage();
-  const messageMediator = new MessageMediator();
-  const consentStorage = new ConsentStorage();
-  const sentivisor = new Sentivisor(
-    new ConsultantProvider(),
-    new SupervisorProvider(supervisorStorage, blackListStorage)
-  );
+const blackListStorage = new BlackListStorage();
+const supervisorStorage = new SupervisorStorage();
+const messageMediator = new MessageMediator();
+const consentStorage = new ConsentStorage();
+const sentivisor = new Sentivisor(
+  new ConsultantProvider(),
+  new SupervisorProvider(supervisorStorage, blackListStorage)
+);
 
-  const isCurrentPageBlackListed = (): Promise<boolean> => {
-    const primaryDomain = getPrimaryDomain();
-    return blackListStorage.isDomainBlacklisted(primaryDomain);
-  };
+const isCurrentPageBlackListed = (): Promise<boolean> => {
+  const primaryDomain = getPrimaryDomain();
+  return blackListStorage.isDomainBlacklisted(primaryDomain);
+};
 
-  const isSupervisionOff = async (): Promise<boolean> => {
-    return (await supervisorStorage.getVisionMode()) === SupervisionMode.off;
-  };
+const isSupervisionOff = async (): Promise<boolean> => {
+  return (await supervisorStorage.getVisionMode()) === SupervisionMode.off;
+};
 
-  const isConsentDeclined = async (): Promise<boolean> => {
-    return !(await consentStorage.getConsent());
-  };
+const isConsentDeclined = async (): Promise<boolean> => {
+  return !(await consentStorage.getConsent());
+};
 
-  let cachedEvaluation: DisplayableData | undefined = undefined;
+let cachedEvaluation: DisplayableData | undefined = undefined;
+// TODO: make getEvaluation cached until it resolves as non-displayable
+const getEvaluation = async (): Promise<DisplayData> => {
+  // TODO: handle this
+  if (await isConsentDeclined()) {
+    console.log("should not parse things");
+    // return
+  }
 
-  const getEvaluation = async (): Promise<DisplayData> => {
-    // TODO: handle this
-    if (await isConsentDeclined()) {
-      console.log("should not parse things");
-      // return
-    }
+  if (await isSupervisionOff()) return { type: "off-supervision-mode" };
+  if (await isCurrentPageBlackListed()) return { type: "black-listed" };
 
-    if (await isSupervisionOff()) return { type: "off-supervision-mode" };
-    if (await isCurrentPageBlackListed()) return { type: "black-listed" };
+  const allTexts: string = document.body.innerText;
+  const lang: string = checkLanguage(allTexts);
 
-    const allTexts: string = document.body.innerText;
-    const lang: string = checkLanguage(allTexts);
+  if (!isAllowedLanguage(lang)) return { type: "unsupported-language" };
 
-    if (!isAllowedLanguage(lang)) return { type: "unsupported-language" };
+  const url = `${location.origin}${location.pathname}`;
 
-    const url = `${location.origin}${location.pathname}`;
+  const emotionAnalysis =
+    cachedEvaluation ||
+    (await messageMediator.send("analyze", {
+      language: lang,
+      text: allTexts,
+      url,
+    }));
 
-    const emotionAnalysis =
-      cachedEvaluation ||
-      (await messageMediator.send("analyze", {
-        language: lang,
-        text: allTexts,
-        url,
-      }));
+  if (emotionAnalysis.type === "displayable")
+    cachedEvaluation = emotionAnalysis;
 
-    if (emotionAnalysis.type === "displayable")
-      cachedEvaluation = emotionAnalysis;
+  return emotionAnalysis!;
+};
 
-    return emotionAnalysis!;
-  };
+messageMediator.listen("getPrimaryDomain", (_msg, _sender, sendResponse) => {
+  sendResponse(getPrimaryDomain());
+});
 
-  messageMediator.listen("getPrimaryDomain", (_msg, _sender, sendResponse) => {
-    sendResponse(getPrimaryDomain());
+messageMediator.listen("getEvaluation", async (tabInfo) => {
+  messageMediator.send("sendEvaluation", {
+    displayData: await getEvaluation(),
+    ...tabInfo,
+  });
+});
+
+const runOnce = async (): Promise<void> => {
+  const alreadyCalledSentivisor = Boolean(cachedEvaluation);
+  if (alreadyCalledSentivisor) return;
+  const tabInfo: TabInfo = await messageMediator.send("getTabInfo", undefined);
+
+  messageMediator.send("sendEvaluation", {
+    ...tabInfo,
+    displayData: { type: "loading" },
+  });
+  const emotionAnalysis = await getEvaluation();
+  messageMediator.send("sendEvaluation", {
+    ...tabInfo,
+    displayData: emotionAnalysis,
   });
 
-  messageMediator.listen("getEvaluation", async (tabInfo) => {
-    messageMediator.send("sendEvaluation", {
-      displayData: await getEvaluation(),
-      ...tabInfo,
-    });
-  });
-
-  const runOnce = async (): Promise<void> => {
-    const alreadyCalledSentivisor = Boolean(cachedEvaluation);
-    if (alreadyCalledSentivisor) return;
-    const emotionAnalysis = await getEvaluation();
-    // TODO: push to sidepanel
-
-    if (emotionAnalysis.type !== "displayable") return;
-    sentivisor.handleEmotionAnalysis(emotionAnalysis.emotionScores);
-  };
-  runOnce();
+  if (emotionAnalysis.type !== "displayable") return;
+  sentivisor.handleEmotionAnalysis(emotionAnalysis.emotionScores);
+};
+runOnce();

--- a/src/content/content.ts
+++ b/src/content/content.ts
@@ -12,11 +12,16 @@ import { ConsentStorage } from "#shared/consent/ConsentStorage";
 import { DisplayableData, DisplayData } from "#shared/messages/display";
 import { TabInfo } from "#shared/messages/tab";
 
+
+// TODO: handle consent changes (this is important later on, when we'll check page regularly not just once)
+//        + in case on the first load the consent was declined, then the user accepted it
+//        then the first parse should happen on handling the consent change
+// TODO: structure code
 // - is eligible to parse
 //    - listen for flags (blacklist, consent, supervision mode)
 // - extract visible part from time to time
 //    - scheduling
-//    - extraction
+//    - content extraction
 
 const blackListStorage = new BlackListStorage();
 const supervisorStorage = new SupervisorStorage();

--- a/src/content/content.ts
+++ b/src/content/content.ts
@@ -9,7 +9,14 @@ import { ConsultantProvider } from "./Consultant/ConsultantProvider";
 import { SupervisorProvider } from "./Supervisor/SupervisorProvider";
 import { SupervisionMode } from "#shared/supervisor/supervision-mode";
 import { ConsentStorage } from "#shared/consent/ConsentStorage";
-import { DisplayableData, DisplayData, TabInfo } from "#shared/messages";
+import { DisplayableData, DisplayData } from "#shared/messages/display";
+import { TabInfo } from "#shared/messages/tab";
+
+// - is eligible to parse
+//    - listen for flags (blacklist, consent, supervision mode)
+// - extract visible part from time to time
+//    - scheduling
+//    - extraction
 
 const blackListStorage = new BlackListStorage();
 const supervisorStorage = new SupervisorStorage();

--- a/src/content/content.ts
+++ b/src/content/content.ts
@@ -9,21 +9,7 @@ import { ConsultantProvider } from "./Consultant/ConsultantProvider";
 import { SupervisorProvider } from "./Supervisor/SupervisorProvider";
 import { SupervisionMode } from "#shared/supervisor/supervision-mode";
 import { ConsentStorage } from "#shared/consent/ConsentStorage";
-import { DisplayableData, DisplayData } from "#shared/messages";
-
-declare global {
-  interface Window {
-    __SENTIVISOR_CONTENT_GUARD_FLAG__: boolean;
-  }
-}
-
-function run() {
-  if (window.__SENTIVISOR_CONTENT_GUARD_FLAG__) {
-    console.log("BINGOOOO");
-    return;
-  }
-
-  window.__SENTIVISOR_CONTENT_GUARD_FLAG__ = true;
+import { DisplayableData, DisplayData, TabInfo } from "#shared/messages";
 
   const blackListStorage = new BlackListStorage();
   const supervisorStorage = new SupervisorStorage();
@@ -101,6 +87,3 @@ function run() {
     sentivisor.handleEmotionAnalysis(emotionAnalysis.emotionScores);
   };
   runOnce();
-}
-
-run();

--- a/src/shared/MessageMediator.ts
+++ b/src/shared/MessageMediator.ts
@@ -4,7 +4,7 @@ type ACallback<EventName extends keyof MessageMap> = (
   message: MessageMap[EventName]["message"],
   sender: chrome.runtime.MessageSender,
   sendResponse: (response?: MessageMap[EventName]["response"]) => void
-) => void;
+) => void | boolean | Promise<unknown>;
 
 type GeneralListener = (
   message: any,
@@ -30,8 +30,11 @@ export class MessageMediator {
       sendResponse
     ) => {
       const parsedMessage: WrappedMessage<EventName> = JSON.parse(message);
+      // https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/runtime/onMessage#sendresponse
+      // so we return the value from the callback, because it might be true to indicate
+      // that this is an async event handler (that keeps open sendResponse channel after the callback is executed)
       if (parsedMessage.eventName === eventName)
-        cb(parsedMessage.messageContent, sender, sendResponse);
+        return cb(parsedMessage.messageContent, sender, sendResponse);
     };
     chrome.runtime.onMessage.addListener(cbWithWrappedFilter);
 

--- a/src/shared/messages.ts
+++ b/src/shared/messages.ts
@@ -11,6 +11,8 @@ export type TabInfo = { tabId: number; windowId: number };
 
 export type ErrorDisplayData = { type: "error"; errorMessage: string };
 
+export type LoadingDisplayData = { type: "loading" };
+
 export type ExceptionDisplayData =
   | { type: "black-listed" }
   | { type: "off-supervision-mode" }
@@ -23,7 +25,10 @@ export type DisplayableData = {
   emotionScores: EmotionScores;
 };
 
-export type DisplayData = ExceptionDisplayData | DisplayableData;
+export type DisplayData =
+  | LoadingDisplayData
+  | ExceptionDisplayData
+  | DisplayableData;
 
 export type AnalyzableContent = {
   // content --> worker

--- a/src/shared/messages.ts
+++ b/src/shared/messages.ts
@@ -7,24 +7,23 @@ export type ParseEvent = {
   response: void;
 };
 
+export type TabInfo = { tabId: number; windowId: number };
+
+export type ErrorDisplayData = { type: "error"; errorMessage: string };
+
 export type ExceptionDisplayData =
   | { type: "black-listed" }
   | { type: "off-supervision-mode" }
   | { type: "inner-page" }
   | { type: "unsupported-language" }
-  | { type: "error"; errorMessage: string };
+  | ErrorDisplayData;
 
-export type DisplayData =
-  | ExceptionDisplayData
-  | {
-      type: "displayable";
-      emotionScores: EmotionScores;
-    };
-
-export type DisplayEvent = {
-  message: DisplayData;
-  response: void;
+export type DisplayableData = {
+  type: "displayable";
+  emotionScores: EmotionScores;
 };
+
+export type DisplayData = ExceptionDisplayData | DisplayableData;
 
 export type AnalyzableContent = {
   // content --> worker
@@ -35,7 +34,7 @@ export type AnalyzableContent = {
 
 export type AnalyzeEvent = {
   message: AnalyzableContent; // content --> worker
-  response: DisplayData;
+  response: DisplayableData | ErrorDisplayData;
 };
 
 export type BlackListChangeEvent = {
@@ -53,15 +52,31 @@ export type ConsentChangeEvent = {
   response: void;
 };
 
+export type GetEvaluationEvent = {
+  message: TabInfo;
+  response: void;
+};
+
+export type SendEvaluationEvent = {
+  message: { displayData: DisplayData } & TabInfo;
+  response: void;
+};
+
+export type TabActivatedEvent = {
+  message?: never;
+  response: void;
+};
+
 // TODO: remove DebugEvent
 export type DebugEvent = {
   message: string;
   response: void;
-}
+};
 
 export type MessageMap = {
-  parse: ParseEvent; // ??? --> content // then after it parsed, it sends "analyze"
-  display: DisplayEvent; // worker, content --> sidepanel
+  act: TabActivatedEvent;
+  getEvaluation: GetEvaluationEvent;
+  sendEvaluation: SendEvaluationEvent;
   analyze: AnalyzeEvent; // content --> worker
   blackListChange: BlackListChangeEvent;
   getPrimaryDomain: GetPrimaryDomainEvent;

--- a/src/shared/messages.ts
+++ b/src/shared/messages.ts
@@ -1,12 +1,6 @@
 import { AllowedLanguage } from "./allowed-languages";
 import { EmotionScores } from "./emotion-scores";
 
-export type ParseEvent = {
-  message: undefined;
-  // TODO: return EmotionScores or undefined
-  response: void;
-};
-
 export type TabInfo = { tabId: number; windowId: number };
 
 export type ErrorDisplayData = { type: "error"; errorMessage: string };

--- a/src/shared/messages.ts
+++ b/src/shared/messages.ts
@@ -53,6 +53,12 @@ export type ConsentChangeEvent = {
   response: void;
 };
 
+// TODO: remove DebugEvent
+export type DebugEvent = {
+  message: string;
+  response: void;
+}
+
 export type MessageMap = {
   parse: ParseEvent; // ??? --> content // then after it parsed, it sends "analyze"
   display: DisplayEvent; // worker, content --> sidepanel
@@ -60,4 +66,5 @@ export type MessageMap = {
   blackListChange: BlackListChangeEvent;
   getPrimaryDomain: GetPrimaryDomainEvent;
   consentChange: ConsentChangeEvent;
+  debug: DebugEvent;
 };

--- a/src/shared/messages.ts
+++ b/src/shared/messages.ts
@@ -72,6 +72,11 @@ export type TabActivatedEvent = {
   response: void;
 };
 
+export type GetTabInfoEvent = {
+  message?: never;
+  response: TabInfo;
+};
+
 // TODO: remove DebugEvent
 export type DebugEvent = {
   message: string;
@@ -80,6 +85,7 @@ export type DebugEvent = {
 
 export type MessageMap = {
   act: TabActivatedEvent;
+  getTabInfo: GetTabInfoEvent;
   getEvaluation: GetEvaluationEvent;
   sendEvaluation: SendEvaluationEvent;
   analyze: AnalyzeEvent; // content --> worker

--- a/src/shared/messages.ts
+++ b/src/shared/messages.ts
@@ -70,7 +70,7 @@ export type TabActivatedEvent = {
 // TODO: remove DebugEvent
 export type DebugEvent = {
   message: string;
-  response: void;
+  response?: string;
 };
 
 export type MessageMap = {

--- a/src/shared/messages/analyze.ts
+++ b/src/shared/messages/analyze.ts
@@ -1,0 +1,14 @@
+import { AllowedLanguage } from "#shared/allowed-languages";
+import { DisplayableData, ErrorDisplayData } from "./display";
+
+export type AnalyzableContent = {
+  // content --> worker
+  text: string;
+  language: AllowedLanguage;
+  url: string;
+};
+
+export type AnalyzeEvent = {
+  message: AnalyzableContent; // content --> worker
+  response: DisplayableData | ErrorDisplayData;
+};

--- a/src/shared/messages/display.ts
+++ b/src/shared/messages/display.ts
@@ -1,0 +1,22 @@
+import { EmotionScores } from "#shared/emotion-scores";
+
+export type ErrorDisplayData = { type: "error"; errorMessage: string };
+
+export type LoadingDisplayData = { type: "loading" };
+
+export type ExceptionDisplayData =
+  | { type: "black-listed" }
+  | { type: "off-supervision-mode" }
+  | { type: "inner-page" }
+  | { type: "unsupported-language" }
+  | ErrorDisplayData;
+
+export type DisplayableData = {
+  type: "displayable";
+  emotionScores: EmotionScores;
+};
+
+export type DisplayData =
+  | LoadingDisplayData
+  | ExceptionDisplayData
+  | DisplayableData;

--- a/src/shared/messages/evaluation.ts
+++ b/src/shared/messages/evaluation.ts
@@ -1,0 +1,12 @@
+import { DisplayData } from "./display";
+import { TabInfo } from "./tab";
+
+export type GetEvaluationEvent = {
+  message: TabInfo;
+  response: void;
+};
+
+export type SendEvaluationEvent = {
+  message: { displayData: DisplayData } & TabInfo;
+  response: void;
+};

--- a/src/shared/messages/index.ts
+++ b/src/shared/messages/index.ts
@@ -1,5 +1,5 @@
-import { AllowedLanguage } from "./allowed-languages";
-import { EmotionScores } from "./emotion-scores";
+import { AllowedLanguage } from "../allowed-languages";
+import { EmotionScores } from "../emotion-scores";
 
 export type TabInfo = { tabId: number; windowId: number };
 

--- a/src/shared/messages/index.ts
+++ b/src/shared/messages/index.ts
@@ -1,40 +1,6 @@
-import { AllowedLanguage } from "../allowed-languages";
-import { EmotionScores } from "../emotion-scores";
-
-export type TabInfo = { tabId: number; windowId: number };
-
-export type ErrorDisplayData = { type: "error"; errorMessage: string };
-
-export type LoadingDisplayData = { type: "loading" };
-
-export type ExceptionDisplayData =
-  | { type: "black-listed" }
-  | { type: "off-supervision-mode" }
-  | { type: "inner-page" }
-  | { type: "unsupported-language" }
-  | ErrorDisplayData;
-
-export type DisplayableData = {
-  type: "displayable";
-  emotionScores: EmotionScores;
-};
-
-export type DisplayData =
-  | LoadingDisplayData
-  | ExceptionDisplayData
-  | DisplayableData;
-
-export type AnalyzableContent = {
-  // content --> worker
-  text: string;
-  language: AllowedLanguage;
-  url: string;
-};
-
-export type AnalyzeEvent = {
-  message: AnalyzableContent; // content --> worker
-  response: DisplayableData | ErrorDisplayData;
-};
+import { AnalyzeEvent } from "./analyze";
+import { GetEvaluationEvent, SendEvaluationEvent } from "./evaluation";
+import { TabActivatedEvent, GetTabInfoEvent } from "./tab";
 
 export type BlackListChangeEvent = {
   message?: undefined;
@@ -49,26 +15,6 @@ export type GetPrimaryDomainEvent = {
 export type ConsentChangeEvent = {
   message: boolean;
   response: void;
-};
-
-export type GetEvaluationEvent = {
-  message: TabInfo;
-  response: void;
-};
-
-export type SendEvaluationEvent = {
-  message: { displayData: DisplayData } & TabInfo;
-  response: void;
-};
-
-export type TabActivatedEvent = {
-  message?: never;
-  response: void;
-};
-
-export type GetTabInfoEvent = {
-  message?: never;
-  response: TabInfo;
 };
 
 // TODO: remove DebugEvent

--- a/src/shared/messages/tab.ts
+++ b/src/shared/messages/tab.ts
@@ -1,0 +1,12 @@
+
+export type TabInfo = { tabId: number; windowId: number; };
+
+export type TabActivatedEvent = {
+  message?: never;
+  response: void;
+};
+
+export type GetTabInfoEvent = {
+  message?: never;
+  response: TabInfo;
+};

--- a/src/shared/utils.ts
+++ b/src/shared/utils.ts
@@ -2,10 +2,17 @@ export type Mutable<T> = {
   -readonly [Key in keyof T]: T[Key];
 };
 
-export const getActiveTab = async (): Promise<chrome.tabs.Tab> => {
-  const [activeTab] = await chrome.tabs.query({
+export const getActiveTab = async (
+  tabs: typeof chrome.tabs
+): Promise<chrome.tabs.Tab> => {
+  const [activeTab] = await tabs.query({
     active: true,
     currentWindow: true,
   });
   return activeTab;
+};
+
+export type UsualTab = chrome.tabs.Tab & { id: number; url: `http${string}` };
+export const isUsualTab = (tab: chrome.tabs.Tab): tab is UsualTab => {
+  return (tab?.id != null && tab.url?.startsWith("http")) || false;
 };

--- a/src/worker/Analyzer.ts
+++ b/src/worker/Analyzer.ts
@@ -1,5 +1,5 @@
 import { EmotionScores } from "#shared/emotion-scores";
-import { AnalyzableContent } from "#shared/messages";
+import { AnalyzableContent } from "#shared/messages/analyze";
 
 export class Analyzer {
   public async analyze({

--- a/src/worker/inject-scripts-into-tabs.ts
+++ b/src/worker/inject-scripts-into-tabs.ts
@@ -1,0 +1,41 @@
+type ContentScript = NonNullable<
+  chrome.runtime.Manifest["content_scripts"]
+>[number];
+
+const injectScriptsIntoTab = async (
+  tab: chrome.tabs.Tab,
+  files: string[] | undefined
+): Promise<void> => {
+  if (!tab.id || !files) return;
+
+  try {
+    await chrome.scripting.executeScript({
+      target: { tabId: tab.id },
+      files,
+    });
+    console.log("Injected into:", tab.url);
+  } catch (err) {
+    console.warn("Could not inject into", tab.url, err);
+  }
+};
+
+const handleContentScript = async (
+  aContentScript: ContentScript
+): Promise<void> => {
+  const matches = aContentScript.matches || [];
+  const tabs = await chrome.tabs.query({ url: matches });
+
+  for (const tab of tabs) {
+    await injectScriptsIntoTab(tab, aContentScript.js);
+  }
+};
+
+export const injectContentScriptIntoAlreadyOpenedPages =
+  async (): Promise<void> => {
+    const manifest = chrome.runtime.getManifest();
+    const contentScripts = manifest.content_scripts || [];
+
+    for (const contentScript of contentScripts) {
+      handleContentScript(contentScript);
+    }
+  };

--- a/src/worker/inject-scripts-into-tabs.ts
+++ b/src/worker/inject-scripts-into-tabs.ts
@@ -1,41 +1,15 @@
-type ContentScript = NonNullable<
-  chrome.runtime.Manifest["content_scripts"]
->[number];
-
-const injectScriptsIntoTab = async (
-  tab: chrome.tabs.Tab,
-  files: string[] | undefined
-): Promise<void> => {
-  if (!tab.id || !files) return;
-
-  try {
-    await chrome.scripting.executeScript({
-      target: { tabId: tab.id },
-      files,
-    });
-    console.log("Injected into:", tab.url);
-  } catch (err) {
-    console.warn("Could not inject into", tab.url, err);
-  }
-};
-
-const handleContentScript = async (
-  aContentScript: ContentScript
-): Promise<void> => {
-  const matches = aContentScript.matches || [];
-  const tabs = await chrome.tabs.query({ url: matches });
-
-  for (const tab of tabs) {
-    await injectScriptsIntoTab(tab, aContentScript.js);
-  }
+const getAllMatchers = (): Array<string> => {
+  const manifest = chrome.runtime.getManifest();
+  const allJoinedMatchers = (manifest.content_scripts || [])
+    .map((aContentScript) => aContentScript.matches || [])
+    .reduce((sum, matchesArray) => [...sum, ...matchesArray], []);
+  return Array.from(new Set(allJoinedMatchers));
 };
 
 export const injectContentScriptIntoAlreadyOpenedPages =
   async (): Promise<void> => {
-    const manifest = chrome.runtime.getManifest();
-    const contentScripts = manifest.content_scripts || [];
-
-    for (const contentScript of contentScripts) {
-      handleContentScript(contentScript);
-    }
+    const tabs = await chrome.tabs.query({ url: getAllMatchers() });
+    return Promise.all(tabs.map((tab) => chrome.tabs.reload(tab.id!))).then(
+      () => {}
+    );
   };

--- a/src/worker/worker.ts
+++ b/src/worker/worker.ts
@@ -66,6 +66,10 @@ messageMediator.listen("analyze", (message, _sender, sendResponse) => {
   return true;
 });
 
+messageMediator.listen("getTabInfo", (_message, sender, sendResponse) => {
+  sendResponse({ tabId: sender.tab!.id!, windowId: sender.tab!.windowId });
+});
+
 messageMediator.listen("debug", (debugMessage, _sender, sendResponse) => {
   console.log("service worker:", debugMessage);
   new Promise((resolve) => setTimeout(resolve, 2_000)).then(() =>

--- a/src/worker/worker.ts
+++ b/src/worker/worker.ts
@@ -1,9 +1,6 @@
 import { MessageMediator } from "#shared/MessageMediator";
-import {
-  AnalyzableContent,
-  DisplayableData,
-  ErrorDisplayData,
-} from "#shared/messages";
+import { AnalyzableContent } from "#shared/messages/analyze";
+import { DisplayableData, ErrorDisplayData } from "#shared/messages/display";
 import { Analyzer } from "./Analyzer";
 import { injectContentScriptIntoAlreadyOpenedPages } from "./inject-scripts-into-tabs";
 

--- a/src/worker/worker.ts
+++ b/src/worker/worker.ts
@@ -1,5 +1,9 @@
 import { MessageMediator } from "#shared/MessageMediator";
-import { DisplayableData, ErrorDisplayData } from "#shared/messages";
+import {
+  AnalyzableContent,
+  DisplayableData,
+  ErrorDisplayData,
+} from "#shared/messages";
 import { Analyzer } from "./Analyzer";
 import { injectContentScriptIntoAlreadyOpenedPages } from "./inject-scripts-into-tabs";
 
@@ -43,22 +47,29 @@ chrome.sidePanel
   .setPanelBehavior({ openPanelOnActionClick: true })
   .catch((error) => console.error(error));
 
-messageMediator.listen("analyze", async (message, _sender, sendResponse) => {
-  let displayData: DisplayableData | ErrorDisplayData;
+const getAnalysis = async (
+  analyzableContent: AnalyzableContent
+): Promise<DisplayableData | ErrorDisplayData> => {
   try {
-    const evaluation = await analyzer.analyze(message);
-    displayData = { type: "displayable", emotionScores: evaluation };
+    const evaluation = await analyzer.analyze(analyzableContent);
+    return { type: "displayable", emotionScores: evaluation };
   } catch (e) {
     const errorMessage = e instanceof Error ? e.message : String(e);
-    displayData = { type: "error", errorMessage };
+    return { type: "error", errorMessage };
   }
-  console.log("the thing that we are going to send back is", displayData);
-  // TODO: this does not work for some reason;
-  console.log("sendResponse", sendResponse);
-  sendResponse(displayData);
+};
+
+// https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/runtime/onMessage#sending_an_asynchronous_response_using_sendresponse
+// no async key on listeners
+messageMediator.listen("analyze", (message, _sender, sendResponse) => {
+  getAnalysis(message).then(sendResponse);
+  return true;
 });
 
-messageMediator.listen("debug", (debugMessage) => {
+messageMediator.listen("debug", (debugMessage, _sender, sendResponse) => {
   console.log("service worker:", debugMessage);
-  messageMediator.send("debug", "I got the message: " + debugMessage);
+  new Promise((resolve) => setTimeout(resolve, 2_000)).then(() =>
+    sendResponse("I got the message: " + debugMessage)
+  );
+  return true;
 });

--- a/src/worker/worker.ts
+++ b/src/worker/worker.ts
@@ -1,60 +1,27 @@
 import { MessageMediator } from "#shared/MessageMediator";
-import { DisplayData } from "#shared/messages";
-import { getActiveTab } from "#shared/utils";
+import { DisplayableData, ErrorDisplayData } from "#shared/messages";
 import { Analyzer } from "./Analyzer";
-
-console.log("worker has started");
+import { injectContentScriptIntoAlreadyOpenedPages } from "./inject-scripts-into-tabs";
 
 const messageMediator = new MessageMediator();
 const analyzer = new Analyzer();
 
-let isSidePanelOpen = false;
-
-function setupContextMenu() {
+const setupContextMenu = (): void => {
   chrome.contextMenus.create({
     id: "sentivisor",
     title: "Sentiment Analysis",
     contexts: ["page"],
   });
-}
-
-type UsualTab = chrome.tabs.Tab & { id: number; url: `http${string}` };
-
-const isUsualTab = (tab: chrome.tabs.Tab): tab is UsualTab => {
-  return (tab?.id != null && tab.url?.startsWith("http")) || false;
 };
 
-const parseActivateTab = async (): Promise<void> => {
-  const activeTab = await getActiveTab();
-  if (isUsualTab(activeTab))
-    messageMediator.send("parse", undefined, activeTab.id);
-  else if (isSidePanelOpen) {
-    messageMediator.send("display", { type: "inner-page" });
-  }
+const openConsentPage = (): void => {
+  chrome.tabs.create({
+    url: chrome.runtime.getURL("src/consent/consent.html"),
+  });
 };
-
-// Listen for tab switches (when a tab is activated)
-chrome.tabs.onActivated.addListener(parseActivateTab);
-
-// Listen for side panel closure (when the side panel is closed)
-chrome.runtime.onConnect.addListener((port) => {
-  if (port.name === "sidepanel") {
-    console.log("Sidepanel opened.");
-    isSidePanelOpen = true;
-    port.onDisconnect.addListener(() => {
-      isSidePanelOpen = false;
-      console.log("Sidepanel closed.");
-    });
-    // __QUESTION__ why do we need to send a parse if the content.ts anyway starts a parse
-    parseActivateTab();
-  }
-});
 
 // Chrome bug workaround
 chrome.runtime.onInstalled.addListener(async (details) => {
-  // Run only on installation, not on updates
-  if (details.reason !== "install") return;
-
   // Retrieve extension information
   const extensionInfo = await chrome.management.getSelf();
   // Check if the URL contains 'sentivisor.com'
@@ -64,10 +31,11 @@ chrome.runtime.onInstalled.addListener(async (details) => {
 
   console.log("onInstalled triggered for Sentivisor extension.");
 
-  // Run necessary actions during installation
-  chrome.tabs.create({
-    url: chrome.runtime.getURL("src/consent/consent.html"),
-  });
+  await injectContentScriptIntoAlreadyOpenedPages();
+
+  // Run only on installation, not on updates
+  if (details.reason !== "install") return;
+  openConsentPage();
   setupContextMenu();
 });
 
@@ -76,8 +44,7 @@ chrome.sidePanel
   .catch((error) => console.error(error));
 
 messageMediator.listen("analyze", async (message, _sender, sendResponse) => {
-  // TODO: get tabid, so when we switch while fetching, we won't show it to the wrong tab
-  let displayData: DisplayData;
+  let displayData: DisplayableData | ErrorDisplayData;
   try {
     const evaluation = await analyzer.analyze(message);
     displayData = { type: "displayable", emotionScores: evaluation };
@@ -85,21 +52,11 @@ messageMediator.listen("analyze", async (message, _sender, sendResponse) => {
     const errorMessage = e instanceof Error ? e.message : String(e);
     displayData = { type: "error", errorMessage };
   }
-  void sendScoresToDisplay(displayData);
+  console.log("the thing that we are going to send back is", displayData);
+  // TODO: this does not work for some reason;
+  console.log("sendResponse", sendResponse);
   sendResponse(displayData);
 });
-
-const sendScoresToDisplay = async (
-  displayableData: DisplayData
-): Promise<void> => {
-  const activeTab = await getActiveTab();
-  if (isUsualTab(activeTab))
-    messageMediator.send("display", displayableData, activeTab.id);
-  // TODO: separate events which goes to content (sends with tabId)
-  //  and events which goes to either worker or to sidepanel
-  //  maybe those can be separated as well
-  if (isSidePanelOpen) messageMediator.send("display", displayableData); // this goes to sidepanel
-};
 
 messageMediator.listen("debug", (debugMessage) => {
   console.log("service worker:", debugMessage);

--- a/src/worker/worker.ts
+++ b/src/worker/worker.ts
@@ -3,6 +3,8 @@ import { DisplayData } from "#shared/messages";
 import { getActiveTab } from "#shared/utils";
 import { Analyzer } from "./Analyzer";
 
+console.log("worker has started");
+
 const messageMediator = new MessageMediator();
 const analyzer = new Analyzer();
 
@@ -98,3 +100,8 @@ const sendScoresToDisplay = async (
   //  maybe those can be separated as well
   if (isSidePanelOpen) messageMediator.send("display", displayableData); // this goes to sidepanel
 };
+
+messageMediator.listen("debug", (debugMessage) => {
+  console.log("service worker:", debugMessage);
+  messageMediator.send("debug", "I got the message: " + debugMessage);
+});


### PR DESCRIPTION
- inject chrome through DI in sidepanel
- TODO: remove debug event
- handle content.js is missing when user has opened pages before (re)installing extension by reloading all pages
  -  TODO: add notification/modal to accept reloading all pages
- move all event messages into its own folder
- fix async message listeners
- switch from `worker --[evaluation]--> sidepanel` communication to `content.js --[evaluation]--> sidepanel`
  this fixes the problem with worker that it "forgets" that sidepanel is opened

closes #27, #34, #46